### PR TITLE
Fix graceful shutdown

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: npm run start
+web: node ./build/index.js


### PR DESCRIPTION
## Context

NPM uses sub-processes when running scripts like `npm run start`. When Heroku sends SIGTERM, the NPM process catches it and terminates, even if the Node code it is running wants to handle SIGTERM.

## Changelog

- Modify Heroku Procfile to run `node ./build/index.js` instead of `npm run start` so that Node code becomes top-level process and can handle SIGTERM as intended.