### PR TITLE
v1.0.0 beta.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "att-voodoo-server",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "att-voodoo-server",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0-beta.7",
   "description": "",
   "main": "build/index.js",
   "scripts": {

--- a/src/api/requestHandlers/getSeal.ts
+++ b/src/api/requestHandlers/getSeal.ts
@@ -1,6 +1,7 @@
 import { RequestHandler } from 'express';
 import { db } from '../../db';
-import { VoodooServer, PreparedSpells } from '../../voodoo';
+import { VoodooServer, PreparedSpells, Prefab, spawn, spawnFrom } from '../../voodoo';
+
 import { selectSession } from '../../db/sql';
 
 const conduitDistance = 10;
@@ -65,6 +66,31 @@ export const getSeal =
           spell.cast(voodoo, accountId);
         }
       } else {
+        if (incantations[0]?.[1] === 'hilted apparatus') {
+          const { prefab } = voodoo.players[accountId].incantations[0].decodedString;
+          const player = await voodoo.getPlayerDetailed({ accountId });
+          const { position, rotation } = spawnFrom(player, 'rightPalm', 0.05);
+
+          const respawn: Prefab = {
+            ...prefab,
+            prefabObject: {
+              ...prefab.prefabObject,
+              position,
+              rotation,
+              scale: 1
+            },
+            components: {
+              ...prefab.components,
+              NetworkRigidbody: {
+                ...prefab.components?.NetworkRigidbody,
+                position,
+                rotation
+              }
+            }
+          };
+
+          spawn(voodoo, accountId, respawn);
+        }
         // @todo somehow feedback that there was no spell associated
       }
 

--- a/src/api/requestHandlers/postIncantation.ts
+++ b/src/api/requestHandlers/postIncantation.ts
@@ -1,7 +1,7 @@
 import { RequestHandler } from 'express';
 import { db } from '../../db';
 import { selectSession } from '../../db/sql';
-import { VoodooServer, PreparedSpells, decodeString, parsePrefab } from '../../voodoo';
+import { VoodooServer, PreparedSpells, Prefab, decodeString, parsePrefab, spawn, spawnFrom } from '../../voodoo';
 
 const conduitDistance = 10;
 
@@ -106,6 +106,31 @@ export const postIncantation =
             await spell.cast(voodoo, accountId);
           }
         } else {
+          if (incantations[0]?.[1] === 'hilted apparatus') {
+            const { prefab } = voodoo.players[accountId].incantations[0].decodedString;
+            const player = await voodoo.getPlayerDetailed({ accountId });
+            const { position, rotation } = spawnFrom(player, 'rightPalm', 0.05);
+
+            const respawn: Prefab = {
+              ...prefab,
+              prefabObject: {
+                ...prefab.prefabObject,
+                position,
+                rotation,
+                scale: 1
+              },
+              components: {
+                ...prefab.components,
+                NetworkRigidbody: {
+                  ...prefab.components?.NetworkRigidbody,
+                  position,
+                  rotation
+                }
+              }
+            };
+
+            spawn(voodoo, accountId, respawn);
+          }
           // @todo somehow feedback that there was no spell associated
         }
 

--- a/src/voodoo/index.ts
+++ b/src/voodoo/index.ts
@@ -1,3 +1,3 @@
 export { createVoodooServer, VoodooServer, Dexterity, PreparedSpells } from './createVoodooServer';
-export { decodeString, parsePrefab } from './spellbook';
+export { decodeString, parsePrefab, Prefab, spawn, spawnFrom } from './spellbook';
 export { gracefulShutdown } from './gracefulShutdown';

--- a/src/voodoo/spellbook/index.ts
+++ b/src/voodoo/spellbook/index.ts
@@ -1,2 +1,4 @@
 export { spellbook, Spellbook, Spell } from './spellbook';
-export { decodeString, DecodedString, parsePrefab } from './strings';
+export { decodeString, DecodedString, parsePrefab, Prefab } from './strings';
+export { spawn } from './spawn';
+export { spawnFrom } from './spawnFrom';


### PR DESCRIPTION
## Changelog

- Respawn consumed weapons on spell misses and nullify. This makes messing up spells like **Repair <Material> Weapon** a little more forgiving as it will only consume your other material components, but gives you back your unrepaired weapon.