### PR TITLE
v1.0.0 beta.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "att-voodoo-server",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "att-voodoo-server",
-  "version": "1.0.0-beta.7",
+  "version": "1.0.0-beta.8",
   "description": "",
   "main": "build/index.js",
   "scripts": {

--- a/src/api/createApi.ts
+++ b/src/api/createApi.ts
@@ -5,12 +5,13 @@ import { VoodooServer } from '../voodoo';
 import { auth } from './middleware';
 import {
   getInfo,
-  getSession,
   getHeartbeat,
+  getSession,
   postIncantation,
   deleteIncantations,
   getSeal,
-  postTrigger
+  postTrigger,
+  getPlayer
 } from './requestHandlers';
 
 const port = process.env.PORT || 3000;
@@ -30,6 +31,7 @@ export const createApi = (voodoo: VoodooServer) => {
   api.delete('/incantation', deleteIncantations(voodoo));
   api.get('/seal', getSeal(voodoo));
   api.post('/trigger', postTrigger(voodoo));
+  api.get('/player', getPlayer(voodoo));
 
   api.listen(port, () => {
     logger.success(`API listening on port ${port}`);

--- a/src/api/requestHandlers/getPlayer.ts
+++ b/src/api/requestHandlers/getPlayer.ts
@@ -1,0 +1,34 @@
+import { RequestHandler } from 'express';
+import { db } from '../../db';
+import { VoodooServer, PreparedSpells } from '../../voodoo';
+import { selectSession, selectPreparedSpells } from '../../db/sql';
+
+export const getPlayer =
+  (voodoo: VoodooServer): RequestHandler =>
+  async (clientRequest, clientResponse) => {
+    const auth = clientRequest.headers.authorization ?? '';
+
+    try {
+      /* Verify the player. */
+      const accessToken = auth.replace(/Bearer\s+/i, '');
+      const session = await db.query(selectSession, [accessToken]);
+
+      if (!session.rows.length) return clientResponse.status(404).json({ ok: false, error: 'Session not found' });
+
+      /* Get player details. */
+      const accountId = session.rows[0].account_id;
+      const { serverId } = voodoo.players[accountId];
+
+      let preparedSpells: PreparedSpells = [];
+
+      if (accountId && serverId) {
+        const storedSpells = await db.query(selectPreparedSpells, [accountId, serverId]);
+        preparedSpells = JSON.parse(storedSpells.rows[0]?.prepared_spells ?? '[]');
+      }
+
+      clientResponse.json({ ok: true, result: { preparedSpells } });
+    } catch (error) {
+      voodoo.logger.error(error);
+      clientResponse.status(500).json({ ok: false, error: error.message });
+    }
+  };

--- a/src/api/requestHandlers/getSeal.ts
+++ b/src/api/requestHandlers/getSeal.ts
@@ -1,7 +1,6 @@
 import { RequestHandler } from 'express';
 import { db } from '../../db';
 import { VoodooServer, PreparedSpells, Prefab, spawn, spawnFrom } from '../../voodoo';
-
 import { selectSession } from '../../db/sql';
 
 const conduitDistance = 10;

--- a/src/api/requestHandlers/index.ts
+++ b/src/api/requestHandlers/index.ts
@@ -1,7 +1,8 @@
 export { deleteIncantations } from './deleteIncantations';
+export { getHeartbeat } from './getHeartbeat';
 export { getInfo } from './getInfo';
+export { getPlayer } from './getPlayer';
 export { getSeal } from './getSeal';
 export { getSession } from './getSession';
-export { getHeartbeat } from './getHeartbeat';
 export { postIncantation } from './postIncantation';
 export { postTrigger } from './postTrigger';

--- a/src/api/requestHandlers/postTrigger.ts
+++ b/src/api/requestHandlers/postTrigger.ts
@@ -22,7 +22,8 @@ export const postTrigger =
 
       /* Get the player's prepared spells. */
       const accountId = session.rows[0].account_id;
-      const storedSpells = await db.query(selectPreparedSpells, [accountId]);
+      const { serverId } = voodoo.players[accountId];
+      const storedSpells = await db.query(selectPreparedSpells, [accountId, serverId]);
 
       if (!storedSpells.rows.length) {
         return clientResponse.status(404).json({
@@ -68,7 +69,7 @@ export const postTrigger =
 
       /* Store new prepared spells list. */
       const newPreparedSpells = JSON.stringify(preparedSpells);
-      await db.query(upsertPreparedSpells, [accountId, newPreparedSpells]);
+      await db.query(upsertPreparedSpells, [accountId, serverId, newPreparedSpells]);
 
       clientResponse.json({ ok: true, result: preparedSpells });
     } catch (error) {

--- a/src/db/sql/createTablePreparedSpells.ts
+++ b/src/db/sql/createTablePreparedSpells.ts
@@ -1,5 +1,9 @@
 const createTablePreparedSpells = `
 CREATE TABLE prepared_spells (
-  account_id integer primary key,
+  account_id integer not null,
+  server_id integer not null,
   prepared_spells text not null
-);`;
+);
+
+CREATE UNIQUE INDEX ON prepared_spells (account_id, server_id);
+`;

--- a/src/db/sql/selectPreparedSpells.ts
+++ b/src/db/sql/selectPreparedSpells.ts
@@ -5,4 +5,5 @@ FROM
   prepared_spells
 WHERE
   account_id = $1
+  AND server_id = $2
 ;`;

--- a/src/db/sql/upsertPreparedSpells.ts
+++ b/src/db/sql/upsertPreparedSpells.ts
@@ -1,8 +1,8 @@
 export const upsertPreparedSpells = `
 INSERT INTO
-  prepared_spells ( account_id, prepared_spells )
-  VALUES ( $1, $2 )
-ON CONFLICT ( account_id )
+  prepared_spells ( account_id, server_id, prepared_spells )
+  VALUES ( $1, $2, $3 )
+ON CONFLICT ( account_id, server_id )
 DO UPDATE SET
-  prepared_spells = $2
+  prepared_spells = $3
 ;`;

--- a/src/voodoo/createVoodooServer.ts
+++ b/src/voodoo/createVoodooServer.ts
@@ -216,8 +216,8 @@ export const createVoodooServer = (): VoodooServer => ({
   },
 
   prepareSpell: async function ({ accountId, incantations, spell }) {
-    const storedSpells = await db.query(selectPreparedSpells, [accountId]);
-
+    const { serverId } = this.players[accountId];
+    const storedSpells = await db.query(selectPreparedSpells, [accountId, serverId]);
     const preparedSpells: PreparedSpells = JSON.parse(storedSpells.rows[0]?.prepared_spells ?? '[]');
     const maxPreparedSpells = 10; // @todo Base this off player level / skills
 
@@ -232,7 +232,7 @@ export const createVoodooServer = (): VoodooServer => ({
     preparedSpells.push(preparedSpell);
     const newPreparedSpells = JSON.stringify(preparedSpells);
 
-    await db.query(upsertPreparedSpells, [accountId, newPreparedSpells]);
+    await db.query(upsertPreparedSpells, [accountId, serverId, newPreparedSpells]);
 
     logger.info(`${accountId} prepared spell: ${spell.name}`);
 

--- a/src/voodoo/gracefulShutdown.ts
+++ b/src/voodoo/gracefulShutdown.ts
@@ -38,6 +38,6 @@ const tick = (voodoo: VoodooServer) => {
 export const gracefulShutdown = (voodoo: VoodooServer) => () => {
   voodoo.logger.warn('SIGTERM received, beginning graceful shutdown.');
 
-  setInterval(() => tick(voodoo), 1000);
+  setInterval(() => tick(voodoo), 970);
   tick(voodoo);
 };


### PR DESCRIPTION
## Changelog

- Save player's prepared spells per server. Fixes bug where player's could prepare spells in one server and cast them in another.
- Create new /player endpoint for future retrieval of player stats. Currently returns prepared spells, which the client retrieves on server connect.
- Ensure graceful shutdown occurs within 30 seconds.