### PR TITLE
Fix Spell Stacking

### DIFF
--- a/src/voodoo/createVoodooServer.ts
+++ b/src/voodoo/createVoodooServer.ts
@@ -351,6 +351,19 @@ export const createVoodooServer = (): VoodooServer => ({
       return undefined;
     }
   },
+  
+  getPlayerCheckStat: async function ({ accountId, stat }) {
+    try {
+      const checkStatResponse: PlayerCheckStatResponse = await this.command({
+        accountId,
+        command: `player check-stat ${accountId} ${stat}`
+      });
+
+      return checkStatResponse.Result?;
+    } catch (error) {
+      return undefined;
+    }
+  },
 
   getPlayerCheckStatBase: async function ({ accountId, stat }) {
     try {

--- a/src/voodoo/spellbook/spells/haste.ts
+++ b/src/voodoo/spellbook/spells/haste.ts
@@ -27,7 +27,7 @@ export const haste: SpellFunction = async (voodoo, accountId, upgradeConfigs) =>
     }
   });
 
-  const multiplier = attributes.intensify / 100;
+  const bonus = attributes.intensify / 100;
   const duration = attributes.concentration;
   const searchRadius = attributes.projection;
 
@@ -44,8 +44,11 @@ export const haste: SpellFunction = async (voodoo, accountId, upgradeConfigs) =>
     const baseSpeed = await voodoo.getPlayerCheckStatBase({ accountId: playerId, stat: 'speed' });
     const currentSpeed = await voodoo.getPlayerCheckStatCurrent({accountId: playerId, stat: 'speed' });
 
-    if (baseSpeed == currentSpeed) {
-      const buffedSpeed = baseSpeed * multiplier;
+    const buffedSpeed = baseSpeed * (1 + bonus);
+    const speedDelta = buffedSpeed - currentSpeed;
+
+    if (speedDelta > 0) {
+      const speedBuff = baseSpeed * bonus;
 
       voodoo.command({
         accountId,

--- a/src/voodoo/spellbook/spells/haste.ts
+++ b/src/voodoo/spellbook/spells/haste.ts
@@ -27,7 +27,7 @@ export const haste: SpellFunction = async (voodoo, accountId, upgradeConfigs) =>
     }
   });
 
-  const multiplier = 1 + attributes.intensify / 100;
+  const multiplier = attributes.intensify / 100;
   const duration = attributes.concentration;
   const searchRadius = attributes.projection;
 
@@ -42,8 +42,9 @@ export const haste: SpellFunction = async (voodoo, accountId, upgradeConfigs) =>
 
   for (const playerId of playerIds) {
     const baseSpeed = await voodoo.getPlayerCheckStatBase({ accountId: playerId, stat: 'speed' });
+    const currentSpeed = await voodoo.getPlayerCheckStatCurrent({accountId: playerId, stat: 'speed' });
 
-    if (baseSpeed) {
+    if (baseSpeed == currentSpeed) {
       const buffedSpeed = baseSpeed * multiplier;
 
       voodoo.command({

--- a/src/voodoo/spellbook/spells/haste.ts
+++ b/src/voodoo/spellbook/spells/haste.ts
@@ -41,14 +41,16 @@ export const haste: SpellFunction = async (voodoo, accountId, upgradeConfigs) =>
   const playerIds = [accountId, ...nearbySoulbondIds];
 
   for (const playerId of playerIds) {
-    const playerSpeed = voodoo.getPlayerCheckStat({ accountId: playerId, stat: 'speed' });
+    const playerSpeed = await voodoo.getPlayerCheckStat({ accountId: playerId, stat: 'speed' });
 
-    const buffedSpeed = playerSpeed.Base * (1 + bonus);
-    
-    const speedDelta = buffedSpeed - playerSpeed.Value;
+    const baseSpeed = playerSpeed.base ?? 1;
+    const currentSpeed = playerSpeed.current ?? 1;
+
+    const buffedSpeed = baseSpeed * (1 + bonus);
+    const speedDelta = buffedSpeed - currentSpeed;
 
     if (speedDelta > 0) {
-      const speedBuff = playerSpeed.Base * bonus;
+      const speedBuff = baseSpeed * bonus;
 
       voodoo.command({
         accountId,

--- a/src/voodoo/spellbook/spells/haste.ts
+++ b/src/voodoo/spellbook/spells/haste.ts
@@ -41,18 +41,18 @@ export const haste: SpellFunction = async (voodoo, accountId, upgradeConfigs) =>
   const playerIds = [accountId, ...nearbySoulbondIds];
 
   for (const playerId of playerIds) {
-    const baseSpeed = await voodoo.getPlayerCheckStatBase({ accountId: playerId, stat: 'speed' });
-    const currentSpeed = await voodoo.getPlayerCheckStatCurrent({accountId: playerId, stat: 'speed' });
+    const playerSpeed = voodoo.getPlayerCheckStat({ accountId: playerId, stat: 'speed' });
 
-    const buffedSpeed = baseSpeed * (1 + bonus);
-    const speedDelta = buffedSpeed - currentSpeed;
+    const buffedSpeed = playerSpeed.base * (1 + bonus);
+    
+    const speedDelta = buffedSpeed - playerSpeed.value;
 
     if (speedDelta > 0) {
-      const speedBuff = baseSpeed * bonus;
+      const speedBuff = playerSpeed.base * bonus;
 
       voodoo.command({
         accountId,
-        command: `player modify-stat ${playerId} speed ${buffedSpeed} ${duration} false`
+        command: `player modify-stat ${playerId} speed ${speedBuff} ${duration} false`
       });
     }
   }

--- a/src/voodoo/spellbook/spells/haste.ts
+++ b/src/voodoo/spellbook/spells/haste.ts
@@ -43,12 +43,12 @@ export const haste: SpellFunction = async (voodoo, accountId, upgradeConfigs) =>
   for (const playerId of playerIds) {
     const playerSpeed = voodoo.getPlayerCheckStat({ accountId: playerId, stat: 'speed' });
 
-    const buffedSpeed = playerSpeed.base * (1 + bonus);
+    const buffedSpeed = playerSpeed.Base * (1 + bonus);
     
-    const speedDelta = buffedSpeed - playerSpeed.value;
+    const speedDelta = buffedSpeed - playerSpeed.Value;
 
     if (speedDelta > 0) {
-      const speedBuff = playerSpeed.base * bonus;
+      const speedBuff = playerSpeed.Base * bonus;
 
       voodoo.command({
         accountId,

--- a/src/voodoo/spellbook/spells/healWounds.ts
+++ b/src/voodoo/spellbook/spells/healWounds.ts
@@ -27,7 +27,7 @@ export const healWounds: SpellFunction = async (voodoo, accountId, upgradeConfig
     }
   });
 
-  const heal = attributes.intensify / 4;
+  const heal = attributes.intensify / 4; // 0.25 equals one "heart"
   const searchRadius = attributes.projection;
 
   let nearbySoulbondIds: number[] = [];

--- a/src/voodoo/spellbook/spells/heroism.ts
+++ b/src/voodoo/spellbook/spells/heroism.ts
@@ -47,29 +47,23 @@ export const heroism: SpellFunction = async (voodoo, accountId, upgradeConfigs) 
     ]);
 
     let buffedMaxHealth = 0,
-      buffedHealth = 0,
-      delta = 0;
+      healthDelta = 0;
 
     /* Raise max health. */
     if (baseMaxHealth) {
       buffedMaxHealth = baseMaxHealth * multiplier;
-      delta = buffedMaxHealth - baseMaxHealth;
+      healthDelta = buffedMaxHealth - baseMaxHealth;
     }
 
-    /* Increase health by same amount as max health buff. */
-    if (currentHealth && delta) {
-      buffedHealth = currentHealth + delta;
-    }
-
-    if (buffedMaxHealth && buffedHealth) {
+    if (buffedMaxHealth && healthDelta) {
       voodoo.command({
         accountId,
-        command: `player modify-stat ${playerId} maxhealth ${buffedMaxHealth} ${duration} false`
+        command: `player modify-stat ${playerId} maxhealth ${healthDelta} ${duration} false`
       });
 
       voodoo.command({
         accountId,
-        command: `player modify-stat ${playerId} health ${buffedHealth} ${duration} false`
+        command: `player modify-stat ${playerId} health ${healthDelta} ${duration} false`
       });
     }
   }

--- a/src/voodoo/spellbook/spells/stoneskin.ts
+++ b/src/voodoo/spellbook/spells/stoneskin.ts
@@ -35,7 +35,7 @@ export const stoneskin: SpellFunction = async (voodoo, accountId, upgradeConfigs
     }
   });
 
-  const multiplier = attributes.intensify / 100;
+  const bonus = attributes.intensify / 100;
   const duration = attributes.concentration;
   const searchRadius = attributes.projection;
 
@@ -52,8 +52,13 @@ export const stoneskin: SpellFunction = async (voodoo, accountId, upgradeConfigs
     const baseDamageProtection = await voodoo.getPlayerCheckStatBase({ accountId: playerId, stat: 'damageprotection' });
     const currentDamageProtection = await voodoo.getPlayerCheckStatCurrent({ accountId: playerId, stat: 'damageprotection' })
 
-    if (baseDamageProtection == currentDamageProtection) {
-      const buffedDamageProtection = baseDamageProtection * multiplier;
+    const buffedDamageProtection = baseSpeed * (1 + bonus);
+    
+    const damageprotectionDelta = buffedDamageProtection - currentDamageProtection;
+    
+    
+    if (damageprotectionDelta > 0) {
+      const damageprotectionBuff = baseDamageProtection * bonus;
 
       voodoo.command({
         accountId,

--- a/src/voodoo/spellbook/spells/stoneskin.ts
+++ b/src/voodoo/spellbook/spells/stoneskin.ts
@@ -49,20 +49,19 @@ export const stoneskin: SpellFunction = async (voodoo, accountId, upgradeConfigs
   const playerIds = [accountId, ...nearbySoulbondIds];
 
   for (const playerId of playerIds) {
-    const baseDamageProtection = await voodoo.getPlayerCheckStatBase({ accountId: playerId, stat: 'damageprotection' });
-    const currentDamageProtection = await voodoo.getPlayerCheckStatCurrent({ accountId: playerId, stat: 'damageprotection' })
+    const playerDamageProtection = voodoo.getPlayerCheckStat({ accountId: playerId, stat: 'speed' });
 
-    const buffedDamageProtection = baseSpeed * (1 + bonus);
+    const buffedDamageProtection = playerDamageProtection.base * (1 + bonus);
     
-    const damageprotectionDelta = buffedDamageProtection - currentDamageProtection;
+    const damageprotectionDelta = buffedDamageProtection - playerDamageProtection.value;
     
     
     if (damageprotectionDelta > 0) {
-      const damageprotectionBuff = baseDamageProtection * bonus;
+      const damageprotectionBuff = playerDamageProtection.base * bonus;
 
       voodoo.command({
         accountId,
-        command: `player modify-stat ${playerId} damageprotection ${buffedDamageProtection} ${duration} false`
+        command: `player modify-stat ${playerId} damageprotection ${damageprotectionBuff} ${duration} false`
       });
     }
   }

--- a/src/voodoo/spellbook/spells/stoneskin.ts
+++ b/src/voodoo/spellbook/spells/stoneskin.ts
@@ -51,13 +51,13 @@ export const stoneskin: SpellFunction = async (voodoo, accountId, upgradeConfigs
   for (const playerId of playerIds) {
     const playerDamageProtection = voodoo.getPlayerCheckStat({ accountId: playerId, stat: 'speed' });
 
-    const buffedDamageProtection = playerDamageProtection.base * (1 + bonus);
+    const buffedDamageProtection = playerDamageProtection.Base * (1 + bonus);
     
-    const damageprotectionDelta = buffedDamageProtection - playerDamageProtection.value;
+    const damageprotectionDelta = buffedDamageProtection - playerDamageProtection.Value;
     
     
     if (damageprotectionDelta > 0) {
-      const damageprotectionBuff = playerDamageProtection.base * bonus;
+      const damageprotectionBuff = playerDamageProtection.Base * bonus;
 
       voodoo.command({
         accountId,

--- a/src/voodoo/spellbook/spells/stoneskin.ts
+++ b/src/voodoo/spellbook/spells/stoneskin.ts
@@ -49,15 +49,16 @@ export const stoneskin: SpellFunction = async (voodoo, accountId, upgradeConfigs
   const playerIds = [accountId, ...nearbySoulbondIds];
 
   for (const playerId of playerIds) {
-    const playerDamageProtection = voodoo.getPlayerCheckStat({ accountId: playerId, stat: 'speed' });
+    const playerDamageProtection = await voodoo.getPlayerCheckStat({ accountId: playerId, stat: 'damageprotection' });
 
-    const buffedDamageProtection = playerDamageProtection.Base * (1 + bonus);
-    
-    const damageprotectionDelta = buffedDamageProtection - playerDamageProtection.Value;
-    
-    
+    const baseDamageProtection = playerDamageProtection.base ?? 0;
+    const currentDamageProtection = playerDamageProtection.current ?? 0;
+
+    const buffedDamageProtection = baseDamageProtection * (1 + bonus);
+    const damageprotectionDelta = buffedDamageProtection - currentDamageProtection;
+
     if (damageprotectionDelta > 0) {
-      const damageprotectionBuff = playerDamageProtection.Base * bonus;
+      const damageprotectionBuff = baseDamageProtection * bonus;
 
       voodoo.command({
         accountId,

--- a/src/voodoo/spellbook/spells/stoneskin.ts
+++ b/src/voodoo/spellbook/spells/stoneskin.ts
@@ -35,7 +35,7 @@ export const stoneskin: SpellFunction = async (voodoo, accountId, upgradeConfigs
     }
   });
 
-  const multiplier = 1 + attributes.intensify / 100;
+  const multiplier = attributes.intensify / 100;
   const duration = attributes.concentration;
   const searchRadius = attributes.projection;
 
@@ -50,8 +50,9 @@ export const stoneskin: SpellFunction = async (voodoo, accountId, upgradeConfigs
 
   for (const playerId of playerIds) {
     const baseDamageProtection = await voodoo.getPlayerCheckStatBase({ accountId: playerId, stat: 'damageprotection' });
+    const currentDamageProtection = await voodoo.getPlayerCheckStatCurrent({ accountId: playerId, stat: 'damageprotection' })
 
-    if (baseDamageProtection) {
+    if (baseDamageProtection == currentDamageProtection) {
       const buffedDamageProtection = baseDamageProtection * multiplier;
 
       voodoo.command({

--- a/src/voodoo/spellbook/spells/trueStrike.ts
+++ b/src/voodoo/spellbook/spells/trueStrike.ts
@@ -27,7 +27,7 @@ export const trueStrike: SpellFunction = async (voodoo, accountId, upgradeConfig
     }
   });
 
-  const multiplier = 1 + attributes.intensify / 100;
+  const multiplier = attributes.intensify / 100;
   const duration = attributes.concentration;
   const searchRadius = attributes.projection;
 
@@ -42,6 +42,7 @@ export const trueStrike: SpellFunction = async (voodoo, accountId, upgradeConfig
 
   for (const playerId of playerIds) {
     const baseDamage = await voodoo.getPlayerCheckStatBase({ accountId: playerId, stat: 'damage' });
+    const currentDamage = await voodoo.getPlayerCheckStatCurrent({ accountId: playerId, stat: 'damage' })
 
     if (baseDamage) {
       const buffedDamage = baseDamage * multiplier;

--- a/src/voodoo/spellbook/spells/trueStrike.ts
+++ b/src/voodoo/spellbook/spells/trueStrike.ts
@@ -41,20 +41,19 @@ export const trueStrike: SpellFunction = async (voodoo, accountId, upgradeConfig
   const playerIds = [accountId, ...nearbySoulbondIds];
 
   for (const playerId of playerIds) {
-    const baseDamage = await voodoo.getPlayerCheckStatBase({ accountId: playerId, stat: 'damage' });
-    const currentDamage = await voodoo.getPlayerCheckStatCurrent({ accountId: playerId, stat: 'damage' })
+    const playerDamage = await voodoo.getPlayerCheckStat({ accountId: playerId, stat: 'damage' });
 
-    const buffedDamage = baseDamage * (1 + bonus);
+    const buffedDamage = playerDamage.base * (1 + bonus);
     
-    const damageDelta = buffedDamage - currentDamage;
+    const damageDelta = buffedDamage - playerDamage.value;
     
     
     if (damageDelta > 0) {
-      const damageBuff = baseDamage * bonus;
+      const damageBuff = playerDamage.base * bonus;
 
       voodoo.command({
         accountId,
-        command: `player modify-stat ${playerId} damage ${buffedDamage} ${duration} false`
+        command: `player modify-stat ${playerId} damage ${damageBuff} ${duration} false`
       });
     }
   }

--- a/src/voodoo/spellbook/spells/trueStrike.ts
+++ b/src/voodoo/spellbook/spells/trueStrike.ts
@@ -27,7 +27,7 @@ export const trueStrike: SpellFunction = async (voodoo, accountId, upgradeConfig
     }
   });
 
-  const multiplier = attributes.intensify / 100;
+  const bonus = attributes.intensify / 100;
   const duration = attributes.concentration;
   const searchRadius = attributes.projection;
 
@@ -44,8 +44,13 @@ export const trueStrike: SpellFunction = async (voodoo, accountId, upgradeConfig
     const baseDamage = await voodoo.getPlayerCheckStatBase({ accountId: playerId, stat: 'damage' });
     const currentDamage = await voodoo.getPlayerCheckStatCurrent({ accountId: playerId, stat: 'damage' })
 
-    if (baseDamage) {
-      const buffedDamage = baseDamage * multiplier;
+    const buffedDamage = baseDamage * (1 + bonus);
+    
+    const damageDelta = buffedDamage - currentDamage;
+    
+    
+    if (damageDelta > 0) {
+      const damageBuff = baseDamage * bonus;
 
       voodoo.command({
         accountId,

--- a/src/voodoo/spellbook/spells/trueStrike.ts
+++ b/src/voodoo/spellbook/spells/trueStrike.ts
@@ -43,13 +43,13 @@ export const trueStrike: SpellFunction = async (voodoo, accountId, upgradeConfig
   for (const playerId of playerIds) {
     const playerDamage = await voodoo.getPlayerCheckStat({ accountId: playerId, stat: 'damage' });
 
-    const buffedDamage = playerDamage.base * (1 + bonus);
+    const buffedDamage = playerDamage.Base * (1 + bonus);
     
-    const damageDelta = buffedDamage - playerDamage.value;
+    const damageDelta = buffedDamage - playerDamage.Value;
     
     
     if (damageDelta > 0) {
-      const damageBuff = playerDamage.base * bonus;
+      const damageBuff = playerDamage.Base * bonus;
 
       voodoo.command({
         accountId,

--- a/src/voodoo/spellbook/spells/trueStrike.ts
+++ b/src/voodoo/spellbook/spells/trueStrike.ts
@@ -43,13 +43,14 @@ export const trueStrike: SpellFunction = async (voodoo, accountId, upgradeConfig
   for (const playerId of playerIds) {
     const playerDamage = await voodoo.getPlayerCheckStat({ accountId: playerId, stat: 'damage' });
 
-    const buffedDamage = playerDamage.Base * (1 + bonus);
-    
-    const damageDelta = buffedDamage - playerDamage.Value;
-    
-    
+    const baseDamage = playerDamage.base ?? 1;
+    const currentDamage = playerDamage.current ?? 1;
+
+    const buffedDamage = baseDamage * (1 + bonus);
+    const damageDelta = buffedDamage - currentDamage;
+
     if (damageDelta > 0) {
-      const damageBuff = playerDamage.Base * bonus;
+      const damageBuff = baseDamage * bonus;
 
       voodoo.command({
         accountId,


### PR DESCRIPTION
I believe this should stop people from being able to cast multiple spells as well as account for the additive nature of the modify-stat command. what I mean by that is that the command, instead of setting the stat to the value you give it, it adds the value to the current stat, creating some unintended levels of speed. review it and deem if it's necessary to merge into the base repository.