### PR TITLE
Return consumed materials for unfinished incantations

### DIFF
--- a/src/voodoo/createVoodooServer.ts
+++ b/src/voodoo/createVoodooServer.ts
@@ -566,6 +566,8 @@ export const createVoodooServer = (): VoodooServer => ({
 
       spawn(this, accountId, respawn);
     }
+
+    this.clearIncantations({ accountId });
   },
 
   command: async function ({ accountId, command }) {

--- a/src/voodoo/createVoodooServer.ts
+++ b/src/voodoo/createVoodooServer.ts
@@ -1,8 +1,8 @@
 import ua, { Visitor } from 'universal-analytics';
 import { ServerConnection } from 'js-tale';
 import Logger from 'js-tale/dist/logger';
-import { DecodedString } from 'att-string-transcoder';
-import { spellbook, Spellbook, Spell, School, upgradeAttribute, UpgradeConfig } from './spellbook';
+import { DecodedString, PrefabData } from 'att-string-transcoder';
+import { spellbook, Spellbook, Spell, School, upgradeAttribute, UpgradeConfig, spawnFrom, spawn } from './spellbook';
 import { db } from '../db';
 import {
   selectExperience,
@@ -192,6 +192,10 @@ interface ClearIncantations {
   accountId: number;
 }
 
+interface ReturnMaterials {
+  accountId: number;
+}
+
 interface Command {
   accountId: number;
   command: string;
@@ -251,6 +255,7 @@ export type VoodooServer = {
   setDexterity: ({ accountId, dexterity }: SetDexterity) => void;
   addIncantation: ({ accountId, incantation }: AddIncantation) => SpellpageIncantation[];
   clearIncantations: ({ accountId }: ClearIncantations) => SpellpageIncantation[];
+  returnMaterials: ({ accountId }: ReturnMaterials) => void;
   command: ({ accountId, command }: Command) => Promise<any>;
   prepareSpell: ({ accountId, incantations, spell }: PrepareSpell) => Promise<PreparedSpells>;
   track: ({ accountId, serverId, category, action, value }: Track) => void;
@@ -529,6 +534,38 @@ export const createVoodooServer = (): VoodooServer => ({
     logger.success(`[${player.serverName ?? player.serverId} | ${player.name}] cleared incantations`);
 
     return [];
+  },
+
+  returnMaterials: async function ({ accountId }) {
+    const player = this.players[accountId];
+
+    if (!player) return;
+
+    for (const incantation of player.incantations) {
+      const { prefab } = incantation.decodedString;
+      const playerDetailed = await this.getPlayerDetailed({ accountId });
+      const { position, rotation } = spawnFrom(playerDetailed, 'eyes', 1);
+
+      const respawn: PrefabData = {
+        ...prefab,
+        prefabObject: {
+          ...prefab.prefabObject,
+          position,
+          rotation,
+          scale: 1
+        },
+        components: {
+          ...prefab.components,
+          NetworkRigidbody: {
+            ...prefab.components?.NetworkRigidbody,
+            position,
+            rotation
+          }
+        }
+      };
+
+      spawn(this, accountId, respawn);
+    }
   },
 
   command: async function ({ accountId, command }) {

--- a/src/voodoo/gracefulShutdown.ts
+++ b/src/voodoo/gracefulShutdown.ts
@@ -8,7 +8,7 @@ let showTimeLeft = false;
  * Print either a warning message or the remaining time before termination.
  */
 const message = (timeLeft: number) =>
-  showTimeLeft ? `Voodoo service is restarting in ${timeLeft} seconds` : 'Please finish your incantations!';
+  showTimeLeft ? `Voodoo service is restarting in ${timeLeft} seconds` : 'Please hold your incantations!';
 
 /**
  * Count down during graceful shutdown and exit process.
@@ -40,4 +40,11 @@ export const gracefulShutdown = (voodoo: VoodooServer) => () => {
 
   setInterval(() => tick(voodoo), 970);
   tick(voodoo);
+
+  /* Return all consumed spell materials for unfinished incantations. */
+  for (const key in voodoo.players) {
+    const accountId = Number(key);
+
+    voodoo.returnMaterials({ accountId });
+  }
 };


### PR DESCRIPTION
## Context

Voodoo Server has a graceful shutdown mechanism. During the 30-second grace period, Voodoo alerts players of the imminent shutdown and urges them to finish speaking their incantations before their consumed spell materials are lost.

While Voodoo Server is able to keep sending messages to ATT game servers (as evidenced by the fact `player message` commands keep arriving throughout the grace period), it does not actually seem to accept any new inbound requests. This means that players trying to finish speaking their incantations actually can't.

It is unfair to take players' spell materials without warning (which is what this grace period attempted to do). Because under normal circumstances we wouldn't know when Heroku is going to restart the server, we can't predict when to warn players of an imminent restart. Therefore the best alternative is to simply return all consumed spell materials when Voodoo Server receives the shutdown signal.

## Changes

- Added a `returnMaterials` helper method. When called, will spawn all stored strings in front of the player and then clear the stored incantations.
- Added a loop over all players and calling `returnMaterials` on all of them in the graceful shutdown handler.